### PR TITLE
fix missing import and package name in docs and example

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Limit size of POST requests for Gin framework
 package main
 
 import (
+	"net/http"
 	"github.com/gin-contrib/size"
 	"github.com/gin-gonic/gin"
 )
@@ -29,7 +30,7 @@ func handler(ctx *gin.Context) {
 
 func main() {
 	rtr := gin.Default()
-	rtr.Use(ratelimit.RateLimiter(10))
+	rtr.Use(limits.RateLimiter(10))
 	rtr.POST("/", handler)
 	rtr.Run(":8080")
 }

--- a/example/main.go
+++ b/example/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"net/http"
 	"github.com/gin-contrib/size"
 	"github.com/gin-gonic/gin"
 )
@@ -15,7 +16,7 @@ func handler(ctx *gin.Context) {
 
 func main() {
 	rtr := gin.Default()
-	rtr.Use(ratelimit.RateLimiter(10))
+	rtr.Use(limits.RateLimiter(10))
 	rtr.POST("/", handler)
 	rtr.Run(":8080")
 }


### PR DESCRIPTION
fix missing import and package name in docs and example